### PR TITLE
Scoped the javascript endanimation event to triggered element only

### DIFF
--- a/BlazorAnimation/wwwroot/blazorAnimationInterop.js
+++ b/BlazorAnimation/wwwroot/blazorAnimationInterop.js
@@ -6,5 +6,7 @@ document.getElementsByTagName("head")[0].insertAdjacentHTML(
 
 var AnimatedComponent = AnimatedComponent || {};
 AnimatedComponent.animationend = function (element, dotNet) {
-    element.addEventListener('animationend', function () { dotNet.invokeMethodAsync("OnAnimationEnd") });
+    element.addEventListener('animationend', function(e) {
+        if(e.target === this)dotNet.invokeMethodAsync("OnAnimationEnd") 
+    });
 };


### PR DESCRIPTION
I was having problems with the OnAnimationEnd triggering with all of the children so I added a conditional statement in the javascript to only trigger when the targeted elements is finished.
```
<Animation Effect="@Effect.FadeOut" Enabled="FadeSplash" OnAnimationEnd="SplashFaded">
        <MudGrid Justify="Justify.Center" Class="logos-splash" Spacing="12">
            <MudItem >
                <MudLink Href="#" @onmouseover="MVLogoMouseOver" @onmouseout="MVLogoMouseOut" @onclick="@MVLogoOnClick">
                    <Animation Effect="@Effect.Pulse" Enabled="MVLogoAnimate" >
                        <MVLogo Width="300px" Height="300px" />
                    </Animation>
                </MudLink>
            </MudItem>
            <MudItem xs="1"></MudItem>
            <MudItem>
                <Animation Effect="@Effect.Pulse" Enabled="THLogoAnimate" Speed=".5">
                    <MudLink @onmouseover="THLogoMouseOver" @onmouseout="THLogoMouseOut" Href="Https://todd-henderson.shop"><THLogo /></MudLink>
                </Animation>
            </MudItem>
        </MudGrid>
    </Animation>
}
```