### PR TITLE
2.3.0: Uses Parameters over Options

### DIFF
--- a/BlazorAnimation/Animation.razor
+++ b/BlazorAnimation/Animation.razor
@@ -26,15 +26,26 @@
 
     [Parameter] public RenderFragment ChildContent { get; set; }
 
-    [Parameter] public bool Enabled { get; set; } = true;
+    [Parameter] public bool Enabled
+    {
+        get => _enabled ?? true;
+        set => _enabled = value;
+    }
 
     [Parameter] public string OptionsName { get; set; } = Options.DefaultName;
 
     [Parameter] public AnimationEffect Effect { get; set; }
 
-    [Parameter] public TimeSpan Delay { get; set; } = BlazorAnimation.Delay.None;
+    [Parameter] public TimeSpan Delay {
+      get => _delay ?? BlazorAnimation.Delay.None;
+      set => _delay = value;
+    }
 
-    [Parameter] public TimeSpan Speed { get; set; } = BlazorAnimation.Speed.Slow;
+    [Parameter] public TimeSpan Speed
+    {
+      get => _speed ?? BlazorAnimation.Speed.Slow;
+      set => _speed = value;
+    }
 
     [Parameter] public string Class { get; set; } = string.Empty;
 
@@ -43,7 +54,9 @@
     [Parameter]
     public int IterationCount
     {
-        get => _iterationCount < 0 ? int.MaxValue : _iterationCount;
+        get => _iterationCount is null
+                    ? 1
+                    : _iterationCount < 0 ? int.MaxValue : _iterationCount.Value;
         set => _iterationCount = value;
     }
 
@@ -54,7 +67,10 @@
     public async void AnimationEnd() => await _animationEnd.InvokeAsync(this);
 
     private EventCallback _animationEnd;
-    private int _iterationCount = 1;
+    private int? _iterationCount;
+    private bool? _enabled;
+    private TimeSpan? _speed;
+    private TimeSpan? _delay;
 
     [CascadingParameter(Name = "OnAnimationEnd")]
     private EventCallback CascadingOnAnimationEnd
@@ -72,11 +88,15 @@
     {
         var options = OptionsSnapshot.Get(OptionsName);
         if (options == null) return;
-        Effect = options.Effect ?? Effect;
-        Delay = options.Delay ?? Delay;
-        Speed = options.Speed ?? Speed;
-        IterationCount = options.IterationCount ?? IterationCount;
-        Enabled = options.Enabled ?? Enabled;
+        Effect ??= options.Effect;
+        if (options.Delay is not null && Delay == BlazorAnimation.Delay.None)
+            Delay = options.Delay.Value;
+        if (options.Speed is not null && Speed == BlazorAnimation.Speed.Slow)
+            Speed = options.Speed.Value;
+        if (options.IterationCount is not null && _iterationCount is null)
+            IterationCount = options.IterationCount.Value;
+        if (options.Enabled is not null && _enabled is null)
+            Enabled = options.Enabled.Value;
     }
 }
 

--- a/BlazorAnimation/BlazorAnimation.csproj
+++ b/BlazorAnimation/BlazorAnimation.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RazorLangVersion>3.0</RazorLangVersion>
-    <Version>2.2.0</Version>
+    <LangVersion>latest</LangVersion>
+    <Version>2.3.0</Version>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>Aurelien BOUDOUX</Authors>
     <Description>a Blazor component based on animate.css to easly animate your content</Description>
@@ -11,7 +12,7 @@
     <PackageProjectUrl>https://github.com/aboudoux/BlazorAnimation</PackageProjectUrl>
     <PackageIcon>BlazorAnimation.png</PackageIcon>
     <PackageIconUrl />
-    <PackageReleaseNotes>OnAnimationEnd is triggered for element only</PackageReleaseNotes>
+    <PackageReleaseNotes>Allows parameters to override options</PackageReleaseNotes>
     <PackageTags>Blazor Animation Animate Html Content</PackageTags>
     <RepositoryUrl>https://github.com/aboudoux/BlazorAnimation</RepositoryUrl>
   </PropertyGroup>


### PR DESCRIPTION
This "fixes" this: #10.

I believe it makes more sense to use component's instance's parameters over the `AnimationOptions`. If you don't believe so, tis alright.

To test, add default options or a named option and watch the demo page completely ignore either of them. Remove a parameter from demo page and see it take the value of the corresponding option.